### PR TITLE
Allow ESP32 SPI pins to be reassigned

### DIFF
--- a/Adafruit_VS1053.cpp
+++ b/Adafruit_VS1053.cpp
@@ -288,6 +288,11 @@ Adafruit_VS1053::Adafruit_VS1053(int8_t mosi, int8_t miso, int8_t clk,
   _dcs = dcs;
   _dreq = dreq;
 
+#ifdef ESP32
+
+  useHardwareSPI = true;
+
+#else // Software SPI
   useHardwareSPI = false;
 
   clkportreg = portOutputRegister(digitalPinToPort(_clk));
@@ -296,6 +301,7 @@ Adafruit_VS1053::Adafruit_VS1053(int8_t mosi, int8_t miso, int8_t clk,
   misopin = digitalPinToBitMask(_miso);
   mosiportreg = portOutputRegister(digitalPinToPort(_mosi));
   mosipin = digitalPinToBitMask(_mosi);
+#endif
 }
 
 
@@ -478,7 +484,14 @@ uint8_t Adafruit_VS1053::begin(void) {
     pinMode(_clk, OUTPUT);
     pinMode(_miso, INPUT);
   } else {
+#ifdef ESP32
+  if (_clk) // If clk is not 0, we're defining the SPI pins
+    SPI.begin(_clk, _miso, _mosi, _cs);
+  else 
     SPI.begin();
+#else
+    SPI.begin();
+#endif
     SPI.setDataMode(SPI_MODE0);
     SPI.setBitOrder(MSBFIRST);
     SPI.setClockDivider(SPI_CLOCK_DIV128); 

--- a/Adafruit_VS1053.cpp
+++ b/Adafruit_VS1053.cpp
@@ -103,7 +103,7 @@ boolean Adafruit_VS1053_FilePlayer::useInterrupt(uint8_t type) {
 #if defined(SPI_HAS_TRANSACTION) && !defined(ESP8266) && !defined(ESP32) && !defined(ARDUINO_STM32_FEATHER)
     SPI.usingInterrupt(irq);
 #endif
-    attachInterrupt(irq, feeder, CHANGE);
+    attachInterrupt(irq, feeder, RISING);
     return true;
   }
   return false;

--- a/Adafruit_VS1053.h
+++ b/Adafruit_VS1053.h
@@ -114,7 +114,7 @@ typedef volatile RwReg PortReg;
 class Adafruit_VS1053 {
  public:
   /*!
-   * @brief Software SPI constructor - must specify all pins
+   * @brief Software (hardware for ESP32) SPI constructor - must specify all pins
    * @param mosi MOSI (Microcontroller Out Serial In) pin
    * @param miso MISO (Microcontroller In Serial Out) pin
    * @param clk Clock pin

--- a/Adafruit_VS1053.h
+++ b/Adafruit_VS1053.h
@@ -27,13 +27,18 @@
 #endif
 
 #include <SPI.h> 
+#if defined(PREFER_SDFAT_LIBRARY)
+#include <SdFat.h>
+extern SdFat SD;
+#else
 #include <SD.h>
+#endif
 
 // define here the size of a register!
 #if defined(ARDUINO_STM32_FEATHER)
   typedef volatile uint32 RwReg;
   typedef uint32_t PortMask;
-#elif defined (__AVR__)
+#elif defined(ARDUINO_ARCH_AVR)
   typedef volatile uint8_t RwReg;
   typedef uint8_t PortMask;
 #elif defined (__arm__)
@@ -57,8 +62,8 @@
 
 typedef volatile RwReg PortReg;
 
-#define VS1053_FILEPLAYER_TIMER0_INT 255 // allows useInterrupt to accept pins 0 to 254
-#define VS1053_FILEPLAYER_PIN_INT 5
+#define VS1053_FILEPLAYER_TIMER0_INT 255 //!< allows useInterrupt to accept pins 0 to 254
+#define VS1053_FILEPLAYER_PIN_INT 5 //!< Allows useInterrupt to accept pins 0 to 4
 
 #define VS1053_SCI_READ 0x03
 #define VS1053_SCI_WRITE 0x02
@@ -81,69 +86,203 @@ typedef volatile RwReg PortReg;
 
 #define VS1053_INT_ENABLE  0xC01A
 
-#define VS1053_MODE_SM_DIFF 0x0001
-#define VS1053_MODE_SM_LAYER12 0x0002
-#define VS1053_MODE_SM_RESET 0x0004
-#define VS1053_MODE_SM_CANCEL 0x0008
-#define VS1053_MODE_SM_EARSPKLO 0x0010
-#define VS1053_MODE_SM_TESTS 0x0020
-#define VS1053_MODE_SM_STREAM 0x0040
-#define VS1053_MODE_SM_SDINEW 0x0800
-#define VS1053_MODE_SM_ADPCM 0x1000
-#define VS1053_MODE_SM_LINE1 0x4000
-#define VS1053_MODE_SM_CLKRANGE 0x8000
+#define VS1053_MODE_SM_DIFF 0x0001 //!< Differential, 0: normal in-phase audio, 1: left channel inverted
+#define VS1053_MODE_SM_LAYER12 0x0002  //!< Allow MPEG layers I & II
+#define VS1053_MODE_SM_RESET 0x0004    //!< Soft reset
+#define VS1053_MODE_SM_CANCEL 0x0008   //!< Cancel decoding current file
+#define VS1053_MODE_SM_EARSPKLO 0x0010 //!< EarSpeaker low setting
+#define VS1053_MODE_SM_TESTS 0x0020    //!< Allow SDI tests
+#define VS1053_MODE_SM_STREAM 0x0040   //!< Stream mode
+#define VS1053_MODE_SM_SDINEW 0x0800   //!< VS1002 native SPI modes
+#define VS1053_MODE_SM_ADPCM 0x1000    //!< PCM/ADPCM recording active
+#define VS1053_MODE_SM_LINE1 0x4000 //!< MIC/LINE1 selector, 0: MICP, 1: LINE1
+#define VS1053_MODE_SM_CLKRANGE 0x8000 //!< Input clock range, 0: 12..13 MHz, 1: 24..26 MHz
 
 
-#define VS1053_SCI_AIADDR 0x0A
-#define VS1053_SCI_AICTRL0 0x0C
-#define VS1053_SCI_AICTRL1 0x0D
-#define VS1053_SCI_AICTRL2 0x0E
-#define VS1053_SCI_AICTRL3 0x0F
+#define VS1053_SCI_AIADDR 0x0A //!< Indicates the start address of the application code written earlier
+                               //!< with SCI_WRAMADDR and SCI_WRAM registers.
+#define VS1053_SCI_AICTRL0 0x0C //!< SCI_AICTRL register 0. Used to access the user's application program
+#define VS1053_SCI_AICTRL1 0x0D //!< SCI_AICTRL register 1. Used to access the user's application program
+#define VS1053_SCI_AICTRL2 0x0E //!< SCI_AICTRL register 2. Used to access the user's application program
+#define VS1053_SCI_AICTRL3 0x0F //!< SCI_AICTRL register 3. Used to access the user's application program
 
-#define VS1053_DATABUFFERLEN 32
+#define VS1053_DATABUFFERLEN 32 //!< Length of the data buffer
 
-
+/*!
+ * Driver for the Adafruit VS1053
+ */
 class Adafruit_VS1053 {
  public:
+  /*!
+   * @brief Software SPI constructor - must specify all pins
+   * @param mosi MOSI (Microcontroller Out Serial In) pin
+   * @param miso MISO (Microcontroller In Serial Out) pin
+   * @param clk Clock pin
+   * @param rst Reset pin
+   * @param cs SCI Chip Select pin
+   * @param dcs SDI Chip Select pin
+   * @param dreq Data Request pin
+   */
   Adafruit_VS1053(int8_t mosi, int8_t miso, int8_t clk, 
 		  int8_t rst, int8_t cs, int8_t dcs, int8_t dreq);
+  /*!
+   * @brief Hardware SPI constructor - assumes hardware SPI pins
+   * @param rst Reset pin
+   * @param cs SCI Chip Select pin
+   * @param dcs SDI Chip Select pin
+   * @param dreq Data Request pin
+   */
   Adafruit_VS1053(int8_t rst, int8_t cs, int8_t dcs, int8_t dreq);
+  /*!
+   * @brief Initialize communication and (hard) reset the chip.
+   * @return Returns true if a VS1053 is found
+   */
   uint8_t begin(void);
+  /*!
+   * @brief Performs a hard reset of the chip
+   */
   void reset(void);
+  /*!
+   * @brief Attempts a soft reset of the chip
+   */
   void softReset(void);
+  /*!
+   * @brief Reads from the specified register on the chip
+   * @param addr Register address to read from
+   * @return Retuns the 16-bit data corresponding to the received address
+   */
   uint16_t sciRead(uint8_t addr);
+  /*!
+   * @brief Writes to the specified register on the chip
+   * @param addr Register address to write to
+   * @param data Data to write
+   */
   void sciWrite(uint8_t addr, uint16_t data);
+  /*!
+   * @brief Generate a sine-wave test signal
+   * @param n Defines the sine test to use
+   * @param ms Delay (in ms)
+   */
   void sineTest(uint8_t n, uint16_t ms);
+  /*!
+   * @brief Low-level SPI write operation
+   * @param d What to write
+   */
   void spiwrite(uint8_t d);
+  /*!
+   * @brief Low-level SPI write operation
+   * @param c Pointer to a buffer containing the data to send
+   * @param num How many elements in the buffer should be sent
+   */
   void spiwrite(uint8_t *c, uint16_t num); 
+  /*!
+   * @brief Low-level SPI read operation
+   * @return Returns a byte read from SPI
+   */
   uint8_t spiread(void);
 
+  /*!
+   * @brief Reads the DECODETIME register from the chip
+   * @return Returns the decode time as an unsigned 16-bit integer
+   */
   uint16_t decodeTime(void);
+  /*!
+   * @brief Set the output volume for the chip
+   * @param left Desired left channel volume
+   * @param right Desired right channel volume
+   */
   void setVolume(uint8_t left, uint8_t right);
+  /*!
+   * @brief Prints the contents of the MODE, STATUS, CLOCKF and VOLUME registers
+   */
   void dumpRegs(void);
 
+  /*!
+   * @brief Decode and play the contents of the supplied buffer
+   * @param buffer Buffer to decode and play
+   * @param buffsiz Size to decode and play
+   */
   void playData(uint8_t *buffer, uint8_t buffsiz);
+  /*!
+   * @brief Test if ready for more data
+   * @return Returns true if it is ready for data
+   */
   boolean readyForData(void);
+  /*!
+   * @brief Apply a code patch
+   * @param patch Patch to apply
+   * @param patchsize Patch size
+   */
   void applyPatch(const uint16_t *patch, uint16_t patchsize);
+  /*!
+   * @brief Load the specified plug-in
+   * @param fn Plug-in to load
+   * @return Either returns 0xFFFF if there is an error, or the address of the
+   * plugin that was loaded
+   */
   uint16_t loadPlugin(char *fn);
 
+  /*!
+   * @brief Write to a GPIO pin
+   * @param i GPIO pin to write to
+   * @param val Value to write
+   */
   void GPIO_digitalWrite(uint8_t i, uint8_t val);
+  /*!
+   * @brief Write to all 8 GPIO pins at once
+   * @param i Value to write
+   */
   void GPIO_digitalWrite(uint8_t i);
+  /*!
+   * @brief Read all 8 GPIO pins at once
+   * @return Returns a 2 byte value with the reads from the 8 pins
+   */
   uint16_t GPIO_digitalRead(void);
+  /*!
+   * @brief Read a single GPIO pin
+   * @param i pin to read
+   * @return Returns the state of the specified GPIO pin
+   */
   boolean GPIO_digitalRead(uint8_t i);
+  /*!
+   * @brief Set the Pin Mode (INPUT/OUTPUT) for a GPIO pin.
+   * @param i Pin to set the mode for
+   * @param dir Mode to set
+   */
   void GPIO_pinMode(uint8_t i, uint8_t dir);
  
+  /*!
+   * @brief Initialize chip for OGG recording
+   * @param plugin Binary file of the plugin to use
+   * @return Returns true if the device is ready to record
+   */
   boolean prepareRecordOgg(char *plugin);
+  /*!
+   * @brief Start recording
+   * @param mic mic=true for microphone input
+   */
   void startRecordOgg(boolean mic);
+  /*!
+   * @brief Stop the recording
+   */
   void stopRecordOgg(void);
+  /*!
+   * @brief Returns the number of words recorded
+   * @return 2-byte unsigned int with the number of words
+   */
   uint16_t recordedWordsWaiting(void);
+  /*!
+   * @brief Reads the next word from the buffer of recorded words
+   * @return Returns the 16-bit data corresponding to the received address
+   */
   uint16_t recordedReadWord(void);
 
-  uint8_t mp3buffer[VS1053_DATABUFFERLEN];
+  uint8_t mp3buffer[VS1053_DATABUFFERLEN]; //!< mp3 buffer that gets sent to the device
 
 #ifdef ARDUINO_ARCH_SAMD
 protected:
   uint32_t  _dreq;
+
 private:
   int32_t _mosi, _miso, _clk, _reset, _cs, _dcs;
   boolean useHardwareSPI;
@@ -156,27 +295,107 @@ private:
 #endif
 };
 
-
+/*!
+ * @brief File player for the Adafruit VS1053
+ */
 class Adafruit_VS1053_FilePlayer : public Adafruit_VS1053 {
  public:
-  Adafruit_VS1053_FilePlayer (int8_t mosi, int8_t miso, int8_t clk, 
-			      int8_t rst, int8_t cs, int8_t dcs, int8_t dreq,
-			      int8_t cardCS);
-  Adafruit_VS1053_FilePlayer (int8_t rst, int8_t cs, int8_t dcs, int8_t dreq,
-			      int8_t cardCS);
-  Adafruit_VS1053_FilePlayer (int8_t cs, int8_t dcs, int8_t dreq,
+  /*!
+   * @brief Software SPI constructor. Uses Software SPI, so you must specify all
+   * SPI pins
+   * @param mosi MOSI (Microcontroller Out Serial In) pin
+   * @param miso MISO (Microcontroller In Serial Out) pin
+   * @param clk Clock pin
+   * @param rst Reset pin
+   * @param cs SCI Chip Select pin
+   * @param dcs SDI Chip Select pin
+   * @param dreq Data Request pin
+   * @param cardCS CS pin for the SD card on the SPI bus
+   */
+  Adafruit_VS1053_FilePlayer(int8_t mosi, int8_t miso, int8_t clk, int8_t rst,
+                             int8_t cs, int8_t dcs, int8_t dreq, int8_t cardCS);
+  /*!
+   * @brief Hardware SPI constructor. Uses Hardware SPI and assumes the default
+   * SPI pins
+   * @param rst Reset pin
+   * @param cs SCI Chip Select pin
+   * @param dcs SDI Chip Select pin
+   * @param dreq Data Request pin
+   * @param cardCS CS pin for the SD card on the SPI bus
+   */
+  Adafruit_VS1053_FilePlayer (int8_t rst, int8_t cs, int8_t dcs, int8_t dreq,\
 			      int8_t cardCS);
 
+  /*!
+   * @brief Hardware SPI constructor. Uses Hardware SPI and assumes the default
+   * SPI pins
+   * @param cs SCI Chip Select pin
+   * @param dcs SDI Chip Select pin
+   * @param dreq Data Request pin
+   * @param cardCS CS pin for the SD card on the SPI bus
+   */
+  Adafruit_VS1053_FilePlayer (int8_t cs, int8_t dcs, int8_t dreq,
+			      int8_t cardCS);
+  /*!
+   * @brief Initialize communication and reset the chip.
+   * @return Returns true if a VS1053 is found
+   */
   boolean begin(void);
+  /*!
+   * @brief Specifies the argument to use for interrupt-driven playback
+   * @param type interrupt to use. Valid arguments are
+   * VS1053_FILEPLAYER_TIMER0_INT and VS1053_FILEPLAYER_PIN_INT
+   * @return Returs true/false for success/failure
+   */
   boolean useInterrupt(uint8_t type);
   File currentTrack;
   volatile boolean playingMusic;
+  /*!
+   * @brief Feeds the buffer. Reads mp3 file data from the SD card and file and
+   * puts it into the buffer that the decoder reads from to play a file
+   */
   void feedBuffer(void);
+  /*!
+   * @brief Checks if the inputted filename is an mp3
+   * @param fileName File to check
+   * @return Returns true or false
+   */
+  static boolean isMP3File(const char *fileName);
+  /*!
+   * @brief Checks for an ID3 tag at the beginning of the file.
+   * @param mp3 File to read
+   * @return returns the seek position within the file where the mp3 data starts
+   */
+  unsigned long mp3_ID3Jumper(File mp3);
+  /*!
+   * @brief Begin playing the specified file from the SD card using
+   * interrupt-drive playback.
+   * @param *trackname File to play
+   * @return Returns true when file starts playing
+   */
   boolean startPlayingFile(const char *trackname);
+  /*!
+   * @brief Play the complete file. This function will not return until the
+   * playback is complete
+   * @param *trackname File to play
+   * @return Returns true when file starts playing
+   */
   boolean playFullFile(const char *trackname);
-  void stopPlaying(void);
+  void stopPlaying(void); //!< Stop playback
+  /*!
+   * @brief If playback is paused
+   * @return Returns true if playback is paused
+   */
   boolean paused(void);
+  /*!
+   * @brief If playback is stopped
+   * @return Returns true if playback is stopped
+   */
   boolean stopped(void);
+  /*!
+   * @brief Pause playback
+   * @param pause whether or not to pause playback
+   */
   void pausePlaying(boolean pause);
 
  private:

--- a/Adafruit_VS1053.h
+++ b/Adafruit_VS1053.h
@@ -301,7 +301,7 @@ private:
 class Adafruit_VS1053_FilePlayer : public Adafruit_VS1053 {
  public:
   /*!
-   * @brief Software SPI constructor. Uses Software SPI, so you must specify all
+   * @brief Software (hardware for ESP32) SPI constructor. Uses Software SPI, so you must specify all
    * SPI pins
    * @param mosi MOSI (Microcontroller Out Serial In) pin
    * @param miso MISO (Microcontroller In Serial Out) pin

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-This is an update of the [Adafruit VS1053 Library](https://github.com/danclarke/Adafruit_VS1053_Library) as modified by Dan Clarke, adding support for user-specified SPI pins.
+This is an update of the [Adafruit VS1053 Library](https://github.com/danclarke/Adafruit_VS1053_Library) as modified by Dan Clarke, but adding support for user-specified SPI pins.
 
-Other changes from the Adafruit source up to v1.2.0 have now been incorporated into the library files. The examples are still downlevel.
+Other changes from the Adafruit source (since it was forked) up to v1.2.0 have now been incorporated into the library files. The examples are still downlevel.
 
 It's currently not fully tested!

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-This is an update of the [Adafruit VS1053 Library](https://github.com/adafruit/Adafruit_VS1053_Library) for ESP32 with Interrupt support
+This is an update of the [Adafruit VS1053 Library](https://github.com/danclarke/Adafruit_VS1053_Library), adding support for user-specified SPI pins.
 
 It's currently not fully tested!

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 This is an update of the [Adafruit VS1053 Library](https://github.com/danclarke/Adafruit_VS1053_Library) as modified by Dan Clarke, adding support for user-specified SPI pins.
 
+Other changes from the Adafruit source up to v1.2.0 have now been incorporated into the library files. The examples are still downlevel.
+
 It's currently not fully tested!

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-This is an update of the [Adafruit VS1053 Library](https://github.com/danclarke/Adafruit_VS1053_Library), adding support for user-specified SPI pins.
+This is an update of the [Adafruit VS1053 Library](https://github.com/danclarke/Adafruit_VS1053_Library) as modified by Dan Clarke, adding support for user-specified SPI pins.
 
 It's currently not fully tested!


### PR DESCRIPTION
I ran into the same problems trying to use the library on an ESP32. Dan Clarke's fix worked well but didn't allow one to change the pins used for the hardware SPI transactions. The changes in this pull request allow the pins to be specified by calling the constructor that specifies the SPI pins as well as the select pins. If this same constructor is used on a non-ESP32 device, then the SPI is handled in software as before.

I've also changed the attachInterrupt() call so that interrupts are only invoked on the rising edge of DREQ as the falling edge should not cause an interrupt.